### PR TITLE
Improved "grow" and "removeIndex"

### DIFF
--- a/src/Containers-SmallOrderedSet/CTSmallOrderedSet.class.st
+++ b/src/Containers-SmallOrderedSet/CTSmallOrderedSet.class.st
@@ -2,48 +2,47 @@
 I am an implementation of an ordered set. Compared to other sets I am very efficient for small sizes, speed- and space-wise. I also mantain the order in which elements are added when iterating.
 "
 Class {
-	#name : 'CTSmallOrderedSet',
-	#superclass : 'Object',
+	#name : #CTSmallOrderedSet,
+	#superclass : #Object,
 	#instVars : [
 		'size',
 		'table'
 	],
-	#category : 'Containers-SmallOrderedSet',
-	#package : 'Containers-SmallOrderedSet'
+	#category : #'Containers-SmallOrderedSet'
 }
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 CTSmallOrderedSet class >> new [
 	^ self new: 3
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 CTSmallOrderedSet class >> new: anInteger [
 	^ self basicNew initialize: anInteger; yourself
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 CTSmallOrderedSet class >> withAll: aDictionary [
 	^ (self new: aDictionary size)
 		addAll: aDictionary;
 		yourself
 ]
 
-{ #category : 'adding' }
+{ #category : #adding }
 CTSmallOrderedSet >> add: newObject [
 	(self findIndexFor: newObject) = 0
 		ifTrue: [ self privateAdd: newObject ].
 	^ newObject
 ]
 
-{ #category : 'adding' }
+{ #category : #adding }
 CTSmallOrderedSet >> addAll: aCollection [
 	aCollection do: [ :each |
 		self add: each ].
 	^ aCollection
 ]
 
-{ #category : 'converting' }
+{ #category : #converting }
 CTSmallOrderedSet >> asArray [
  	| array index | 
 	array := Array new: self size.
@@ -55,25 +54,25 @@ CTSmallOrderedSet >> asArray [
 	^ array
 ]
 
-{ #category : 'enumerating' }
+{ #category : #enumerating }
 CTSmallOrderedSet >> do: aOneArgumentBlock [
 	1 to: size do: [ :i |
 		aOneArgumentBlock value: (table at: i) ]
 ]
 
-{ #category : 'enumerating' }
+{ #category : #enumerating }
 CTSmallOrderedSet >> do: aOneArgumentBlock separatedBy: aNiladicBlock [
 	1 to: size do: [ :i |
 		i > 1 ifTrue: [ aNiladicBlock value ].
 		aOneArgumentBlock value: (table at: i) ]
 ]
 
-{ #category : 'private ' }
+{ #category : #'private ' }
 CTSmallOrderedSet >> errorNotFound [
 	self error: 'Not found'
 ]
 
-{ #category : 'private ' }
+{ #category : #'private ' }
 CTSmallOrderedSet >> findIndexFor: aKey [
 	1 to: size do: [ :index |
 		(table at: index) = aKey
@@ -81,57 +80,56 @@ CTSmallOrderedSet >> findIndexFor: aKey [
 	^ 0
 ]
 
-{ #category : 'private' }
+{ #category : #'private ' }
 CTSmallOrderedSet >> grow [
-    | newTable newSize |
+	| newTable newSize |
     newSize := (table isEmpty) ifTrue: [1] ifFalse: [2 * table size]. "Ensure it grows from 0"
     newTable := Array new: newSize.
     1 to: size do: [ :index |
         newTable at: index put: (table at: index) ].
     table := newTable
-
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSet >> includes: anObject [
 	^ (self findIndexFor: anObject) ~= 0
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 CTSmallOrderedSet >> initialize: anInteger [
 	self initialize.
 	size := 0.
 	table := Array new: anInteger
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSet >> isCollection [
 	^ true
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSet >> isEmpty [
 	^ size = 0
 ]
 
-{ #category : 'copying' }
+{ #category : #copying }
 CTSmallOrderedSet >> postCopy [
 	super postCopy.
 	table := table copy
 ]
 
-{ #category : 'private ' }
+{ #category : #'private ' }
 CTSmallOrderedSet >> privateAdd: newObject [
 	size = table size ifTrue: [ self grow ].
 	table at: (size := size + 1) put: newObject.
 ]
 
-{ #category : 'removing' }
+{ #category : #removing }
 CTSmallOrderedSet >> remove: anObject [
 	^ self remove: anObject ifAbsent: [ self errorNotFound ]
 ]
 
-{ #category : 'removing' }
+{ #category : #removing }
 CTSmallOrderedSet >> remove: anObject ifAbsent: aNiladicBlock [
 	| index |
 	index := self findIndexFor: anObject.
@@ -141,9 +139,9 @@ CTSmallOrderedSet >> remove: anObject ifAbsent: aNiladicBlock [
 	^ anObject
 ]
 
-{ #category : 'private' }
+{ #category : #'private ' }
 CTSmallOrderedSet >> removeIndex: index [
-    (index < 1 or: [ index > size ]) 
+	(index < 1 or: [ index > size ]) 
         ifTrue: [ self error: 'Index out of bounds' ].
     table at: index put: nil.
     (index to: size - 1) do: [ :i |
@@ -152,7 +150,7 @@ CTSmallOrderedSet >> removeIndex: index [
     size := size - 1.
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 CTSmallOrderedSet >> size [
 	^ size
 ]

--- a/src/Containers-SmallOrderedSet/CTSmallOrderedSet.class.st
+++ b/src/Containers-SmallOrderedSet/CTSmallOrderedSet.class.st
@@ -91,7 +91,6 @@ CTSmallOrderedSet >> grow [
 
 ]
 
-
 { #category : #testing }
 CTSmallOrderedSet >> includes: anObject [
 	^ (self findIndexFor: anObject) ~= 0
@@ -141,7 +140,7 @@ CTSmallOrderedSet >> remove: anObject ifAbsent: aNiladicBlock [
 	^ anObject
 ]
 
- #category : #'private' }
+{ #category : #'private' }
 CTSmallOrderedSet >> removeIndex: index [
     (index < 1 or: [ index > size ]) 
         ifTrue: [ self error: 'Index out of bounds' ].
@@ -151,7 +150,6 @@ CTSmallOrderedSet >> removeIndex: index [
     table at: size put: nil.
     size := size - 1.
 ]
-
 
 { #category : #accessing }
 CTSmallOrderedSet >> size [

--- a/src/Containers-SmallOrderedSet/CTSmallOrderedSet.class.st
+++ b/src/Containers-SmallOrderedSet/CTSmallOrderedSet.class.st
@@ -141,12 +141,16 @@ CTSmallOrderedSet >> remove: anObject ifAbsent: aNiladicBlock [
 	^ anObject
 ]
 
-{ #category : 'private ' }
-CTSmallOrderedSet >> removeIndex: index [
-	table at: index put: nil.
-	index to: size - 1 do: [ :i |
-		table at: i put: (table at: i + 1) ].
-	size := size - 1
+{ #category : 'private' }
+CTSmallOrderedSet >> removeIndex: index [ 
+    (index < 1 or: [ index > size ]) 
+        ifTrue: [ self error: 'Index out of bounds' ].
+    table at: index put: nil.
+    index to: size - 1 do: [ :i |
+        table at: i put: (table at: i + 1) ].
+    table at: size put: nil.
+    size := size - 1.
+
 ]
 
 { #category : 'accessing' }

--- a/src/Containers-SmallOrderedSet/CTSmallOrderedSet.class.st
+++ b/src/Containers-SmallOrderedSet/CTSmallOrderedSet.class.st
@@ -2,48 +2,47 @@
 I am an implementation of an ordered set. Compared to other sets I am very efficient for small sizes, speed- and space-wise. I also mantain the order in which elements are added when iterating.
 "
 Class {
-	#name : 'CTSmallOrderedSet',
-	#superclass : 'Object',
+	#name : #CTSmallOrderedSet,
+	#superclass : #Object,
 	#instVars : [
 		'size',
 		'table'
 	],
-	#category : 'Containers-SmallOrderedSet',
-	#package : 'Containers-SmallOrderedSet'
+	#category : #'Containers-SmallOrderedSet'
 }
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 CTSmallOrderedSet class >> new [
 	^ self new: 3
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 CTSmallOrderedSet class >> new: anInteger [
 	^ self basicNew initialize: anInteger; yourself
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 CTSmallOrderedSet class >> withAll: aDictionary [
 	^ (self new: aDictionary size)
 		addAll: aDictionary;
 		yourself
 ]
 
-{ #category : 'adding' }
+{ #category : #adding }
 CTSmallOrderedSet >> add: newObject [
 	(self findIndexFor: newObject) = 0
 		ifTrue: [ self privateAdd: newObject ].
 	^ newObject
 ]
 
-{ #category : 'adding' }
+{ #category : #adding }
 CTSmallOrderedSet >> addAll: aCollection [
 	aCollection do: [ :each |
 		self add: each ].
 	^ aCollection
 ]
 
-{ #category : 'converting' }
+{ #category : #converting }
 CTSmallOrderedSet >> asArray [
  	| array index | 
 	array := Array new: self size.
@@ -55,25 +54,25 @@ CTSmallOrderedSet >> asArray [
 	^ array
 ]
 
-{ #category : 'enumerating' }
+{ #category : #enumerating }
 CTSmallOrderedSet >> do: aOneArgumentBlock [
 	1 to: size do: [ :i |
 		aOneArgumentBlock value: (table at: i) ]
 ]
 
-{ #category : 'enumerating' }
+{ #category : #enumerating }
 CTSmallOrderedSet >> do: aOneArgumentBlock separatedBy: aNiladicBlock [
 	1 to: size do: [ :i |
 		i > 1 ifTrue: [ aNiladicBlock value ].
 		aOneArgumentBlock value: (table at: i) ]
 ]
 
-{ #category : 'private ' }
+{ #category : #'private ' }
 CTSmallOrderedSet >> errorNotFound [
 	self error: 'Not found'
 ]
 
-{ #category : 'private ' }
+{ #category : #'private ' }
 CTSmallOrderedSet >> findIndexFor: aKey [
 	1 to: size do: [ :index |
 		(table at: index) = aKey
@@ -81,8 +80,8 @@ CTSmallOrderedSet >> findIndexFor: aKey [
 	^ 0
 ]
 
-{ #category : 'private' }
-CTSmallOrderedSet >> grow [ 
+{ #category : #'private' }
+CTSmallOrderedSet >> grow [
     | newTable newSize |
     newSize := (table isEmpty) ifTrue: [1] ifFalse: [2 * table size]. "Ensure it grows from 0"
     newTable := Array new: newSize.
@@ -92,46 +91,47 @@ CTSmallOrderedSet >> grow [
 
 ]
 
-{ #category : 'testing' }
+
+{ #category : #testing }
 CTSmallOrderedSet >> includes: anObject [
 	^ (self findIndexFor: anObject) ~= 0
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 CTSmallOrderedSet >> initialize: anInteger [
 	self initialize.
 	size := 0.
 	table := Array new: anInteger
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSet >> isCollection [
 	^ true
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSet >> isEmpty [
 	^ size = 0
 ]
 
-{ #category : 'copying' }
+{ #category : #copying }
 CTSmallOrderedSet >> postCopy [
 	super postCopy.
 	table := table copy
 ]
 
-{ #category : 'private ' }
+{ #category : #'private ' }
 CTSmallOrderedSet >> privateAdd: newObject [
 	size = table size ifTrue: [ self grow ].
 	table at: (size := size + 1) put: newObject.
 ]
 
-{ #category : 'removing' }
+{ #category : #removing }
 CTSmallOrderedSet >> remove: anObject [
 	^ self remove: anObject ifAbsent: [ self errorNotFound ]
 ]
 
-{ #category : 'removing' }
+{ #category : #removing }
 CTSmallOrderedSet >> remove: anObject ifAbsent: aNiladicBlock [
 	| index |
 	index := self findIndexFor: anObject.
@@ -141,19 +141,19 @@ CTSmallOrderedSet >> remove: anObject ifAbsent: aNiladicBlock [
 	^ anObject
 ]
 
-{ #category : 'private' }
-CTSmallOrderedSet >> removeIndex: index [ 
+ #category : #'private' }
+CTSmallOrderedSet >> removeIndex: index [
     (index < 1 or: [ index > size ]) 
         ifTrue: [ self error: 'Index out of bounds' ].
     table at: index put: nil.
-    index to: size - 1 do: [ :i |
+    (index to: size - 1) do: [ :i |
         table at: i put: (table at: i + 1) ].
     table at: size put: nil.
     size := size - 1.
-
 ]
 
-{ #category : 'accessing' }
+
+{ #category : #accessing }
 CTSmallOrderedSet >> size [
 	^ size
 ]

--- a/src/Containers-SmallOrderedSet/CTSmallOrderedSet.class.st
+++ b/src/Containers-SmallOrderedSet/CTSmallOrderedSet.class.st
@@ -2,47 +2,48 @@
 I am an implementation of an ordered set. Compared to other sets I am very efficient for small sizes, speed- and space-wise. I also mantain the order in which elements are added when iterating.
 "
 Class {
-	#name : #CTSmallOrderedSet,
-	#superclass : #Object,
+	#name : 'CTSmallOrderedSet',
+	#superclass : 'Object',
 	#instVars : [
 		'size',
 		'table'
 	],
-	#category : #'Containers-SmallOrderedSet'
+	#category : 'Containers-SmallOrderedSet',
+	#package : 'Containers-SmallOrderedSet'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CTSmallOrderedSet class >> new [
 	^ self new: 3
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CTSmallOrderedSet class >> new: anInteger [
 	^ self basicNew initialize: anInteger; yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CTSmallOrderedSet class >> withAll: aDictionary [
 	^ (self new: aDictionary size)
 		addAll: aDictionary;
 		yourself
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 CTSmallOrderedSet >> add: newObject [
 	(self findIndexFor: newObject) = 0
 		ifTrue: [ self privateAdd: newObject ].
 	^ newObject
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 CTSmallOrderedSet >> addAll: aCollection [
 	aCollection do: [ :each |
 		self add: each ].
 	^ aCollection
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 CTSmallOrderedSet >> asArray [
  	| array index | 
 	array := Array new: self size.
@@ -54,25 +55,25 @@ CTSmallOrderedSet >> asArray [
 	^ array
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 CTSmallOrderedSet >> do: aOneArgumentBlock [
 	1 to: size do: [ :i |
 		aOneArgumentBlock value: (table at: i) ]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 CTSmallOrderedSet >> do: aOneArgumentBlock separatedBy: aNiladicBlock [
 	1 to: size do: [ :i |
 		i > 1 ifTrue: [ aNiladicBlock value ].
 		aOneArgumentBlock value: (table at: i) ]
 ]
 
-{ #category : #'private ' }
+{ #category : 'private ' }
 CTSmallOrderedSet >> errorNotFound [
 	self error: 'Not found'
 ]
 
-{ #category : #'private ' }
+{ #category : 'private ' }
 CTSmallOrderedSet >> findIndexFor: aKey [
 	1 to: size do: [ :index |
 		(table at: index) = aKey
@@ -80,56 +81,57 @@ CTSmallOrderedSet >> findIndexFor: aKey [
 	^ 0
 ]
 
-{ #category : #'private ' }
-CTSmallOrderedSet >> grow [
-	| newTable |
-	"#replaceFrom:to:with:startingAt: would be better but not portable"
-	newTable := Array new: 2 * size.
-	1 to: size do: [ :index |
-		newTable at: index put: (table at: index) ].
-	table := newTable
+{ #category : 'private' }
+CTSmallOrderedSet >> grow [ 
+    | newTable newSize |
+    newSize := (table isEmpty) ifTrue: [1] ifFalse: [2 * table size]. "Ensure it grows from 0"
+    newTable := Array new: newSize.
+    1 to: size do: [ :index |
+        newTable at: index put: (table at: index) ].
+    table := newTable
+
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSet >> includes: anObject [
 	^ (self findIndexFor: anObject) ~= 0
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 CTSmallOrderedSet >> initialize: anInteger [
 	self initialize.
 	size := 0.
 	table := Array new: anInteger
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSet >> isCollection [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSet >> isEmpty [
 	^ size = 0
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 CTSmallOrderedSet >> postCopy [
 	super postCopy.
 	table := table copy
 ]
 
-{ #category : #'private ' }
+{ #category : 'private ' }
 CTSmallOrderedSet >> privateAdd: newObject [
 	size = table size ifTrue: [ self grow ].
 	table at: (size := size + 1) put: newObject.
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 CTSmallOrderedSet >> remove: anObject [
 	^ self remove: anObject ifAbsent: [ self errorNotFound ]
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 CTSmallOrderedSet >> remove: anObject ifAbsent: aNiladicBlock [
 	| index |
 	index := self findIndexFor: anObject.
@@ -139,7 +141,7 @@ CTSmallOrderedSet >> remove: anObject ifAbsent: aNiladicBlock [
 	^ anObject
 ]
 
-{ #category : #'private ' }
+{ #category : 'private ' }
 CTSmallOrderedSet >> removeIndex: index [
 	table at: index put: nil.
 	index to: size - 1 do: [ :i |
@@ -147,7 +149,7 @@ CTSmallOrderedSet >> removeIndex: index [
 	size := size - 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CTSmallOrderedSet >> size [
 	^ size
 ]

--- a/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
+++ b/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
@@ -1,24 +1,25 @@
 Class {
-	#name : #CTSmallOrderedSetTest,
-	#superclass : #TestCase,
+	#name : 'CTSmallOrderedSetTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'collection'
 	],
-	#category : #'Containers-SmallOrderedSet'
+	#category : 'Containers-SmallOrderedSet',
+	#package : 'Containers-SmallOrderedSet'
 }
 
-{ #category : #configuration }
+{ #category : 'configuration' }
 CTSmallOrderedSetTest >> collectionClass [
 	^ CTSmallOrderedSet
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 CTSmallOrderedSetTest >> setUp [
 	super setUp.
 	collection := CTSmallOrderedSet new
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testAdd [
 	| object |
 	object := Object new.
@@ -28,7 +29,7 @@ CTSmallOrderedSetTest >> testAdd [
 	self assert: (collection add: object) equals: object
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testAddAll [
 	collection addAll: #(2 1 1).
 	self assert: collection size equals: 2.
@@ -36,26 +37,26 @@ CTSmallOrderedSetTest >> testAddAll [
 	self assert: (collection includes: 2)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testAddAllKeepsOrder [
 	collection addAll: #(2 1 1 3 4 5 5 5 6).
 	self assert: collection size equals: 6.
 	self assert: collection asArray equals: #(2 1 3 4 5 6).
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testAsArray [
 	collection addAll: #(2 1 1).
 	self assert: collection asArray equals: #(2 1).
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testAsArrayWithStrangeOrder [
 	collection addAll: #(2 1 3 2 1).
 	self assert: collection asArray equals: #(2 1 3).
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testCopy [
 	| copy |
 	collection add: 1.
@@ -69,7 +70,7 @@ CTSmallOrderedSetTest >> testCopy [
 	self deny: (copy includes: 2).
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testDo [
 	| seen |
 	collection addAll: #(2 1 1).
@@ -81,14 +82,14 @@ CTSmallOrderedSetTest >> testDo [
 	self assert: (seen at: 2) equals: 1
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testIncludes [
 	self deny: (collection includes: 0).
 	collection add: 0.
 	self assert: (collection includes: 0)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testIsEmpty [
 	self assert: collection isEmpty.
 	collection add: 1.
@@ -97,14 +98,14 @@ CTSmallOrderedSetTest >> testIsEmpty [
 	self assert: collection isEmpty
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testRemove [
 	collection add: 1.
 	self assert: (collection remove: 1) equals: 1.
 	self should: [ collection remove: 1 ] raise: Error
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testRemoveIfAbsent [
 	| absent |
 	collection add: 1.
@@ -117,7 +118,7 @@ CTSmallOrderedSetTest >> testRemoveIfAbsent [
 	self assert: absent.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTSmallOrderedSetTest >> testSize [
 	self assert: collection size equals: 0.
 	collection addAll: #(2 1 1).

--- a/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
+++ b/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
@@ -1,156 +1,129 @@
-"
-I am an implementation of an ordered set. Compared to other sets I am very efficient for small sizes, speed- and space-wise. I also mantain the order in which elements are added when iterating.
-"
 Class {
-	#name : #CTSmallOrderedSet,
-	#superclass : #Object,
+	#name : #CTSmallOrderedSetTest,
+	#superclass : #TestCase,
 	#instVars : [
-		'size',
-		'table'
+		'collection'
 	],
 	#category : #'Containers-SmallOrderedSet'
 }
 
-{ #category : #'instance creation' }
-CTSmallOrderedSet class >> new [
-	^ self new: 3
+{ #category : #configuration }
+CTSmallOrderedSetTest >> collectionClass [
+	^ CTSmallOrderedSet
 ]
 
-{ #category : #'instance creation' }
-CTSmallOrderedSet class >> new: anInteger [
-	^ self basicNew initialize: anInteger; yourself
-]
-
-{ #category : #'instance creation' }
-CTSmallOrderedSet class >> withAll: aDictionary [
-	^ (self new: aDictionary size)
-		addAll: aDictionary;
-		yourself
-]
-
-{ #category : #adding }
-CTSmallOrderedSet >> add: newObject [
-	(self findIndexFor: newObject) = 0
-		ifTrue: [ self privateAdd: newObject ].
-	^ newObject
-]
-
-{ #category : #adding }
-CTSmallOrderedSet >> addAll: aCollection [
-	aCollection do: [ :each |
-		self add: each ].
-	^ aCollection
-]
-
-{ #category : #converting }
-CTSmallOrderedSet >> asArray [
- 	| array index | 
-	array := Array new: self size.
-	index := 1.
-	self do: [ :each | 
-					array at: index put: each.
-					index := index + 1 ].
-				
-	^ array
-]
-
-{ #category : #enumerating }
-CTSmallOrderedSet >> do: aOneArgumentBlock [
-	1 to: size do: [ :i |
-		aOneArgumentBlock value: (table at: i) ]
-]
-
-{ #category : #enumerating }
-CTSmallOrderedSet >> do: aOneArgumentBlock separatedBy: aNiladicBlock [
-	1 to: size do: [ :i |
-		i > 1 ifTrue: [ aNiladicBlock value ].
-		aOneArgumentBlock value: (table at: i) ]
-]
-
-{ #category : #'private ' }
-CTSmallOrderedSet >> errorNotFound [
-	self error: 'Not found'
-]
-
-{ #category : #'private ' }
-CTSmallOrderedSet >> findIndexFor: aKey [
-	1 to: size do: [ :index |
-		(table at: index) = aKey
-			ifTrue: [ ^ index ] ].
-	^ 0
-]
-
-{ #category : #'private ' }
-CTSmallOrderedSet >> grow [
-	| newTable |
-	"#replaceFrom:to:with:startingAt: would be better but not portable"
-	newTable := Array new: 2 * size.
-	1 to: size do: [ :index |
-		newTable at: index put: (table at: index) ].
-	table := newTable
+{ #category : #running }
+CTSmallOrderedSetTest >> setUp [
+	super setUp.
+	collection := CTSmallOrderedSet new
 ]
 
 { #category : #testing }
-CTSmallOrderedSet >> includes: anObject [
-	^ (self findIndexFor: anObject) ~= 0
-]
-
-{ #category : #initialization }
-CTSmallOrderedSet >> initialize: anInteger [
-	self initialize.
-	size := 0.
-	table := Array new: anInteger
-]
-
-{ #category : #testing }
-CTSmallOrderedSet >> isCollection [
-	^ true
+CTSmallOrderedSetTest >> testAdd [
+	| object |
+	object := Object new.
+	self assert: collection size equals: 0.
+	self assert: (collection add: object) equals: object.
+	self assert: collection size equals: 1.
+	self assert: (collection add: object) equals: object
 ]
 
 { #category : #testing }
-CTSmallOrderedSet >> isEmpty [
-	^ size = 0
+CTSmallOrderedSetTest >> testAddAll [
+	collection addAll: #(2 1 1).
+	self assert: collection size equals: 2.
+	self assert: (collection includes: 1).
+	self assert: (collection includes: 2)
 ]
 
-{ #category : #copying }
-CTSmallOrderedSet >> postCopy [
-	super postCopy.
-	table := table copy
+{ #category : #testing }
+CTSmallOrderedSetTest >> testAddAllKeepsOrder [
+	collection addAll: #(2 1 1 3 4 5 5 5 6).
+	self assert: collection size equals: 6.
+	self assert: collection asArray equals: #(2 1 3 4 5 6).
 ]
 
-{ #category : #'private ' }
-CTSmallOrderedSet >> privateAdd: newObject [
-	size = table size ifTrue: [ self grow ].
-	table at: (size := size + 1) put: newObject.
+{ #category : #testing }
+CTSmallOrderedSetTest >> testAsArray [
+	collection addAll: #(2 1 1).
+	self assert: collection asArray equals: #(2 1).
 ]
 
-{ #category : #removing }
-CTSmallOrderedSet >> remove: anObject [
-	^ self remove: anObject ifAbsent: [ self errorNotFound ]
+{ #category : #testing }
+CTSmallOrderedSetTest >> testAsArrayWithStrangeOrder [
+	collection addAll: #(2 1 3 2 1).
+	self assert: collection asArray equals: #(2 1 3).
 ]
 
-{ #category : #removing }
-CTSmallOrderedSet >> remove: anObject ifAbsent: aNiladicBlock [
-	| index |
-	index := self findIndexFor: anObject.
-	index = 0
-		ifTrue: [ ^ aNiladicBlock value ]
-		ifFalse: [ self removeIndex: index ].
-	^ anObject
+{ #category : #testing }
+CTSmallOrderedSetTest >> testCopy [
+	| copy |
+	collection add: 1.
+	copy := collection copy.
+	collection add: 2.
+	
+	self assert: collection size equals: 2.
+	self assert: copy size equals: 1.
+	
+	self assert: (collection includes: 2).
+	self deny: (copy includes: 2).
 ]
 
-{ #category : #'private ' }
-CTSmallOrderedSet >> removeIndex: index [
-	table at: index put: nil.
-	index to: size - 1 do: [ :i |
-		table at: i put: (table at: i + 1) ].
-	size := size - 1
+{ #category : #testing }
+CTSmallOrderedSetTest >> testDo [
+	| seen |
+	collection addAll: #(2 1 1).
+	seen := Array streamContents: [ :stream |
+		collection do: [ :each |
+			stream nextPut: each ] ].
+	self assert: seen size equals: 2.
+	self assert: (seen at: 1) equals: 2.
+	self assert: (seen at: 2) equals: 1
 ]
 
-{ #category : #accessing }
-CTSmallOrderedSet >> size [
-	^ size
+{ #category : #testing }
+CTSmallOrderedSetTest >> testIncludes [
+	self deny: (collection includes: 0).
+	collection add: 0.
+	self assert: (collection includes: 0)
 ]
+
+{ #category : #testing }
+CTSmallOrderedSetTest >> testIsEmpty [
+	self assert: collection isEmpty.
+	collection add: 1.
+	self deny: collection isEmpty.
+	collection remove: 1.
+	self assert: collection isEmpty
+]
+
+{ #category : #testing }
+CTSmallOrderedSetTest >> testRemove [
+	collection add: 1.
+	self assert: (collection remove: 1) equals: 1.
+	self should: [ collection remove: 1 ] raise: Error
+]
+
+{ #category : #testing }
+CTSmallOrderedSetTest >> testRemoveIfAbsent [
+	| absent |
+	collection add: 1.
+	absent := false.
+	
+	self assert: (collection remove: 1 ifAbsent: [ absent := true ]) equals: 1.
+	self deny: absent.
+	
+	collection remove: 1 ifAbsent: [ absent := true ].
+	self assert: absent.
+]
+
+{ #category : #testing }
+CTSmallOrderedSetTest >> testSize [
+	self assert: collection size equals: 0.
+	collection addAll: #(2 1 1).
+	self assert: collection size equals: 2.
+]
+
 { #category : #testing }
 CTSmallOrderedSetTest >> testWithAll [
     | emptySet singleSet duplicateSet orderedSet mixedSet largeSet unorderedSet specialCharSet expected |

--- a/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
+++ b/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
@@ -124,3 +124,50 @@ CTSmallOrderedSetTest >> testSize [
 	collection addAll: #(2 1 1).
 	self assert: collection size equals: 2.
 ]
+
+{ #category : 'testing' }
+CTSmallOrderedSetTest >> testWithAll [
+    | emptySet singleSet duplicateSet orderedSet mixedSet largeSet unorderedSet specialCharSet expected |
+
+    "Empty Collection Input"
+    emptySet := CTSmallOrderedSet withAll: #().
+    self assert: emptySet isEmpty.
+
+    "Single Element Collection"
+    singleSet := CTSmallOrderedSet withAll: #(42). 
+    self assert: singleSet size equals: 1.
+    self assert: (singleSet includes: 42).
+
+    "Collection With Only Duplicates"
+    duplicateSet := CTSmallOrderedSet withAll: #(7 7 7 7 7).
+    self assert: duplicateSet size equals: 1.
+    self assert: (duplicateSet includes: 7).
+
+    "Already Ordered Input"
+    orderedSet := CTSmallOrderedSet withAll: #(10 20 30).
+    expected := #(10 20 30).
+    self assert: orderedSet asArray equals: expected.
+
+    "Mixed Data Types"
+    mixedSet := CTSmallOrderedSet withAll: #(1 'a' 2 'b' 1 'a').
+    self assert: mixedSet size equals: 4.
+    self assert: (mixedSet includes: 1).
+    self assert: (mixedSet includes: 'a').
+    self assert: (mixedSet includes: 2).
+    self assert: (mixedSet includes: 'b').
+
+    "Large Input Collection"
+    largeSet := CTSmallOrderedSet withAll: (1 to: 10000).
+    self assert: largeSet size equals: 10000.
+
+    "Unordered Input"
+    unorderedSet := CTSmallOrderedSet withAll: #(5 2 8 1 3).
+    self assert: unorderedSet asArray equals: #(5 2 8 1 3).
+
+    "Collection With Special Characters"
+    specialCharSet := CTSmallOrderedSet withAll: #('hello' 'world' 'hello!' 'world#').
+    self assert: specialCharSet size equals: 4.
+    self assert: (specialCharSet includes: 'hello!').
+    self assert: (specialCharSet includes: 'world#').
+
+]

--- a/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
+++ b/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
@@ -1,25 +1,24 @@
 Class {
-	#name : 'CTSmallOrderedSetTest',
-	#superclass : 'TestCase',
+	#name : #CTSmallOrderedSetTest,
+	#superclass : #TestCase,
 	#instVars : [
 		'collection'
 	],
-	#category : 'Containers-SmallOrderedSet',
-	#package : 'Containers-SmallOrderedSet'
+	#category : #'Containers-SmallOrderedSet'
 }
 
-{ #category : 'configuration' }
+{ #category : #configuration }
 CTSmallOrderedSetTest >> collectionClass [
 	^ CTSmallOrderedSet
 ]
 
-{ #category : 'running' }
+{ #category : #running }
 CTSmallOrderedSetTest >> setUp [
 	super setUp.
 	collection := CTSmallOrderedSet new
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testAdd [
 	| object |
 	object := Object new.
@@ -29,7 +28,7 @@ CTSmallOrderedSetTest >> testAdd [
 	self assert: (collection add: object) equals: object
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testAddAll [
 	collection addAll: #(2 1 1).
 	self assert: collection size equals: 2.
@@ -37,26 +36,26 @@ CTSmallOrderedSetTest >> testAddAll [
 	self assert: (collection includes: 2)
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testAddAllKeepsOrder [
 	collection addAll: #(2 1 1 3 4 5 5 5 6).
 	self assert: collection size equals: 6.
 	self assert: collection asArray equals: #(2 1 3 4 5 6).
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testAsArray [
 	collection addAll: #(2 1 1).
 	self assert: collection asArray equals: #(2 1).
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testAsArrayWithStrangeOrder [
 	collection addAll: #(2 1 3 2 1).
 	self assert: collection asArray equals: #(2 1 3).
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testCopy [
 	| copy |
 	collection add: 1.
@@ -70,7 +69,7 @@ CTSmallOrderedSetTest >> testCopy [
 	self deny: (copy includes: 2).
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testDo [
 	| seen |
 	collection addAll: #(2 1 1).
@@ -82,14 +81,14 @@ CTSmallOrderedSetTest >> testDo [
 	self assert: (seen at: 2) equals: 1
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testIncludes [
 	self deny: (collection includes: 0).
 	collection add: 0.
 	self assert: (collection includes: 0)
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testIsEmpty [
 	self assert: collection isEmpty.
 	collection add: 1.
@@ -98,14 +97,14 @@ CTSmallOrderedSetTest >> testIsEmpty [
 	self assert: collection isEmpty
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testRemove [
 	collection add: 1.
 	self assert: (collection remove: 1) equals: 1.
 	self should: [ collection remove: 1 ] raise: Error
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testRemoveIfAbsent [
 	| absent |
 	collection add: 1.
@@ -118,7 +117,7 @@ CTSmallOrderedSetTest >> testRemoveIfAbsent [
 	self assert: absent.
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 CTSmallOrderedSetTest >> testSize [
 	self assert: collection size equals: 0.
 	collection addAll: #(2 1 1).

--- a/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
+++ b/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
@@ -1,131 +1,157 @@
+"
+I am an implementation of an ordered set. Compared to other sets I am very efficient for small sizes, speed- and space-wise. I also mantain the order in which elements are added when iterating.
+"
 Class {
-	#name : 'CTSmallOrderedSetTest',
-	#superclass : 'TestCase',
+	#name : #CTSmallOrderedSet,
+	#superclass : #Object,
 	#instVars : [
-		'collection'
+		'size',
+		'table'
 	],
-	#category : 'Containers-SmallOrderedSet',
-	#package : 'Containers-SmallOrderedSet'
+	#category : #'Containers-SmallOrderedSet'
 }
 
-{ #category : 'configuration' }
-CTSmallOrderedSetTest >> collectionClass [
-	^ CTSmallOrderedSet
+{ #category : #'instance creation' }
+CTSmallOrderedSet class >> new [
+	^ self new: 3
 ]
 
-{ #category : 'running' }
-CTSmallOrderedSetTest >> setUp [
-	super setUp.
-	collection := CTSmallOrderedSet new
+{ #category : #'instance creation' }
+CTSmallOrderedSet class >> new: anInteger [
+	^ self basicNew initialize: anInteger; yourself
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testAdd [
-	| object |
-	object := Object new.
-	self assert: collection size equals: 0.
-	self assert: (collection add: object) equals: object.
-	self assert: collection size equals: 1.
-	self assert: (collection add: object) equals: object
+{ #category : #'instance creation' }
+CTSmallOrderedSet class >> withAll: aDictionary [
+	^ (self new: aDictionary size)
+		addAll: aDictionary;
+		yourself
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testAddAll [
-	collection addAll: #(2 1 1).
-	self assert: collection size equals: 2.
-	self assert: (collection includes: 1).
-	self assert: (collection includes: 2)
+{ #category : #adding }
+CTSmallOrderedSet >> add: newObject [
+	(self findIndexFor: newObject) = 0
+		ifTrue: [ self privateAdd: newObject ].
+	^ newObject
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testAddAllKeepsOrder [
-	collection addAll: #(2 1 1 3 4 5 5 5 6).
-	self assert: collection size equals: 6.
-	self assert: collection asArray equals: #(2 1 3 4 5 6).
+{ #category : #adding }
+CTSmallOrderedSet >> addAll: aCollection [
+	aCollection do: [ :each |
+		self add: each ].
+	^ aCollection
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testAsArray [
-	collection addAll: #(2 1 1).
-	self assert: collection asArray equals: #(2 1).
+{ #category : #converting }
+CTSmallOrderedSet >> asArray [
+ 	| array index | 
+	array := Array new: self size.
+	index := 1.
+	self do: [ :each | 
+					array at: index put: each.
+					index := index + 1 ].
+				
+	^ array
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testAsArrayWithStrangeOrder [
-	collection addAll: #(2 1 3 2 1).
-	self assert: collection asArray equals: #(2 1 3).
+{ #category : #enumerating }
+CTSmallOrderedSet >> do: aOneArgumentBlock [
+	1 to: size do: [ :i |
+		aOneArgumentBlock value: (table at: i) ]
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testCopy [
-	| copy |
-	collection add: 1.
-	copy := collection copy.
-	collection add: 2.
-	
-	self assert: collection size equals: 2.
-	self assert: copy size equals: 1.
-	
-	self assert: (collection includes: 2).
-	self deny: (copy includes: 2).
+{ #category : #enumerating }
+CTSmallOrderedSet >> do: aOneArgumentBlock separatedBy: aNiladicBlock [
+	1 to: size do: [ :i |
+		i > 1 ifTrue: [ aNiladicBlock value ].
+		aOneArgumentBlock value: (table at: i) ]
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testDo [
-	| seen |
-	collection addAll: #(2 1 1).
-	seen := Array streamContents: [ :stream |
-		collection do: [ :each |
-			stream nextPut: each ] ].
-	self assert: seen size equals: 2.
-	self assert: (seen at: 1) equals: 2.
-	self assert: (seen at: 2) equals: 1
+{ #category : #'private ' }
+CTSmallOrderedSet >> errorNotFound [
+	self error: 'Not found'
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testIncludes [
-	self deny: (collection includes: 0).
-	collection add: 0.
-	self assert: (collection includes: 0)
+{ #category : #'private ' }
+CTSmallOrderedSet >> findIndexFor: aKey [
+	1 to: size do: [ :index |
+		(table at: index) = aKey
+			ifTrue: [ ^ index ] ].
+	^ 0
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testIsEmpty [
-	self assert: collection isEmpty.
-	collection add: 1.
-	self deny: collection isEmpty.
-	collection remove: 1.
-	self assert: collection isEmpty
+{ #category : #'private ' }
+CTSmallOrderedSet >> grow [
+	| newTable |
+	"#replaceFrom:to:with:startingAt: would be better but not portable"
+	newTable := Array new: 2 * size.
+	1 to: size do: [ :index |
+		newTable at: index put: (table at: index) ].
+	table := newTable
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testRemove [
-	collection add: 1.
-	self assert: (collection remove: 1) equals: 1.
-	self should: [ collection remove: 1 ] raise: Error
+{ #category : #testing }
+CTSmallOrderedSet >> includes: anObject [
+	^ (self findIndexFor: anObject) ~= 0
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testRemoveIfAbsent [
-	| absent |
-	collection add: 1.
-	absent := false.
-	
-	self assert: (collection remove: 1 ifAbsent: [ absent := true ]) equals: 1.
-	self deny: absent.
-	
-	collection remove: 1 ifAbsent: [ absent := true ].
-	self assert: absent.
+{ #category : #initialization }
+CTSmallOrderedSet >> initialize: anInteger [
+	self initialize.
+	size := 0.
+	table := Array new: anInteger
 ]
 
-{ #category : 'testing' }
-CTSmallOrderedSetTest >> testSize [
-	self assert: collection size equals: 0.
-	collection addAll: #(2 1 1).
-	self assert: collection size equals: 2.
+{ #category : #testing }
+CTSmallOrderedSet >> isCollection [
+	^ true
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
+CTSmallOrderedSet >> isEmpty [
+	^ size = 0
+]
+
+{ #category : #copying }
+CTSmallOrderedSet >> postCopy [
+	super postCopy.
+	table := table copy
+]
+
+{ #category : #'private ' }
+CTSmallOrderedSet >> privateAdd: newObject [
+	size = table size ifTrue: [ self grow ].
+	table at: (size := size + 1) put: newObject.
+]
+
+{ #category : #removing }
+CTSmallOrderedSet >> remove: anObject [
+	^ self remove: anObject ifAbsent: [ self errorNotFound ]
+]
+
+{ #category : #removing }
+CTSmallOrderedSet >> remove: anObject ifAbsent: aNiladicBlock [
+	| index |
+	index := self findIndexFor: anObject.
+	index = 0
+		ifTrue: [ ^ aNiladicBlock value ]
+		ifFalse: [ self removeIndex: index ].
+	^ anObject
+]
+
+{ #category : #'private ' }
+CTSmallOrderedSet >> removeIndex: index [
+	table at: index put: nil.
+	index to: size - 1 do: [ :i |
+		table at: i put: (table at: i + 1) ].
+	size := size - 1
+]
+
+{ #category : #accessing }
+CTSmallOrderedSet >> size [
+	^ size
+]
+{ #category : #testing }
 CTSmallOrderedSetTest >> testWithAll [
     | emptySet singleSet duplicateSet orderedSet mixedSet largeSet unorderedSet specialCharSet expected |
 

--- a/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
+++ b/src/Containers-SmallOrderedSet/CTSmallOrderedSetTest.class.st
@@ -170,3 +170,65 @@ CTSmallOrderedSetTest >> testWithAll [
     self assert: (specialCharSet includes: 'world#').
 
 ]
+
+{ #category : #testing }
+CTSmallOrderedSetTest >> testRemoveIndex [
+
+	| collectionSet |
+	"Create a set and add some elements"
+	collectionSet := CTSmallOrderedSet new: 5.
+	collectionSet add: 1.
+	collectionSet add: 2.
+	collectionSet add: 3.
+	collectionSet add: 4.
+
+	"Remove an element by index"
+	collectionSet removeIndex: 2.
+
+	
+	"Test that the collection size decreased"
+	self assert: collectionSet size equals: 3.
+	self assert: (collectionSet asArray) equals: #( 1 3 4 ).
+	"Test that the removed element is no longer in the collection"
+	self deny: (collectionSet includes: 2).
+
+	"Test removing from an empty set"
+	collectionSet := CTSmallOrderedSet new: 0.
+	self should: [ collectionSet removeIndex: 1 ] raise: Error.
+
+	"Test removing from an empty set with error message"
+	collectionSet := CTSmallOrderedSet new: 0.
+	
+
+	"Test removing the first index"
+	collectionSet := CTSmallOrderedSet new: 3.
+	collectionSet add: 1.
+	collectionSet add: 2.
+	collectionSet add: 3.
+	collectionSet removeIndex: 1.
+	self assert: collectionSet size equals: 2.
+	self assert: (collectionSet asArray) equals: #( 2 3 ).
+
+	"Test removing the last index"
+	collectionSet := CTSmallOrderedSet new: 3.
+	collectionSet add: 1.
+	collectionSet add: 2.
+	collectionSet add: 3.
+	collectionSet removeIndex: 3.
+	self assert: collectionSet size equals: 2.
+	self assert: (collectionSet asArray) equals: #( 1 2 ).
+
+	"Test removing an index out of bounds"
+	collectionSet := CTSmallOrderedSet new: 3.
+	collectionSet add: 1.
+	collectionSet add: 2.
+	collectionSet add: 3.
+	self should: [ collectionSet removeIndex: 4 ] raise: Error.
+
+	"Test removing the only element in the set"
+	collectionSet := CTSmallOrderedSet new: 1.
+	collectionSet add: 1.
+	collectionSet removeIndex: 1.
+	self assert: collectionSet isEmpty.
+	self assert: collectionSet size equals: 0
+]

--- a/src/Containers-SmallOrderedSet/package.st
+++ b/src/Containers-SmallOrderedSet/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Containers-SmallOrderedSet' }
+Package { #name : 'Containers-SmallOrderedSet' }

--- a/src/Containers-SmallOrderedSet/package.st
+++ b/src/Containers-SmallOrderedSet/package.st
@@ -1,1 +1,1 @@
-Package { #name : 'Containers-SmallOrderedSet' }
+Package { #name : #'Containers-SmallOrderedSet' }


### PR DESCRIPTION
1. **grow**

- earlier "grow" worked only if the set had a non-zero value
- this was because of its implementation, which was **newTable := Array new: 2 * size.**
- if initial size is 0, 2*size would result in 0 again.
- it has now been modified to work sets with initial capacity as zero.
Here is the new implementation: 
![image](https://github.com/user-attachments/assets/2ce54929-736e-49d3-a7d6-150af0c4a44b)


2. **removeIndex**
-improved to throw error when the index is out of bounds
